### PR TITLE
Fixed bugs when dealing with primitives and multiple matching constructors

### DIFF
--- a/src/main/java/org/qlrm/mapper/JpaResultMapper.java
+++ b/src/main/java/org/qlrm/mapper/JpaResultMapper.java
@@ -2,88 +2,130 @@ package org.qlrm.mapper;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.Query;
 
 public class JpaResultMapper extends ResultMapper {
 
-    @SuppressWarnings("unchecked")
-    public <T> List<T> list(Query q,
-            Class<T> clazz) throws IllegalArgumentException {
-        List<T> result = new ArrayList<T>();
-        List<Object[]> list = postProcessResultList(q.getResultList());
+	private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_BOX_TYPE_MAP = new HashMap<>();
 
-        Constructor<?> ctor = null;
-        // why finding a constructor for each item? The result set is the same!
-        if (list != null && !list.isEmpty()) {
-            ctor = findConstructor(clazz, list.get(0));
-        }
-        for (Object[] obj : list) {
-            result.add((T) createInstance(ctor, obj));
-        }
-        return result;
-    }
+	{
+		PRIMITIVE_TO_BOX_TYPE_MAP.put(int.class, Integer.class);
+		PRIMITIVE_TO_BOX_TYPE_MAP.put(long.class, Long.class);
+		PRIMITIVE_TO_BOX_TYPE_MAP.put(byte.class, Byte.class);
+		PRIMITIVE_TO_BOX_TYPE_MAP.put(boolean.class, Boolean.class);
+		PRIMITIVE_TO_BOX_TYPE_MAP.put(char.class, Character.class);
+		PRIMITIVE_TO_BOX_TYPE_MAP.put(float.class, Float.class);
+		PRIMITIVE_TO_BOX_TYPE_MAP.put(double.class, Double.class);
+	}
 
-    private List<Object[]> postProcessResultList(List<?> rawResults) {
-        List<Object[]> result = new ArrayList<>();
-        for (Object rawResult : rawResults) {
-            result.add(postProcessSingleResult(rawResult));
-        }
+	@SuppressWarnings("unchecked")
+	public <T> List<T> list(Query q, Class<T> clazz) throws IllegalArgumentException {
+		List<T> result = new ArrayList<T>();
+		List<Object[]> list = postProcessResultList(q.getResultList());
 
-        return result;
-    }
+		Constructor<?> ctor = null;
+		// why finding a constructor for each item? The result set is the same!
+		if (list != null && !list.isEmpty()) {
+			ctor = findConstructor(clazz, list.get(0));
+		}
+		for (Object[] obj : list) {
+			result.add((T) createInstance(ctor, obj));
+		}
+		return result;
+	}
 
-    private Object[] postProcessSingleResult(Object rawResult) {
-        return rawResult instanceof Object[] ? (Object[]) rawResult : new Object[]{rawResult};
-    }
+	private List<Object[]> postProcessResultList(List<?> rawResults) {
+		List<Object[]> result = new ArrayList<>();
+		for (Object rawResult : rawResults) {
+			result.add(postProcessSingleResult(rawResult));
+		}
 
-    public <T> T uniqueResult(Query q,
-            Class<T> clazz) {
-        Object[] rec = postProcessSingleResult(q.getSingleResult());
-        Constructor<?> ctor = findConstructor(clazz, rec);
+		return result;
+	}
 
-        return createInstance(ctor, rec);
-    }
+	private Object[] postProcessSingleResult(Object rawResult) {
+		return rawResult instanceof Object[] ? (Object[]) rawResult : new Object[] { rawResult };
+	}
 
-    private Constructor<?> findConstructor(Class<?> clazz, Object... args) {
-        Constructor<?> ctor = null;
-        final Constructor<?>[] ctors = clazz.getDeclaredConstructors();
+	public <T> T uniqueResult(Query q, Class<T> clazz) {
+		Object[] rec = postProcessSingleResult(q.getSingleResult());
+		Constructor<?> ctor = findConstructor(clazz, rec);
 
-        // More stable check
-        if (ctors.length == 1 && ctors[0].getParameterTypes().length == args.length) {
-            // INFO stefanheimberg: wenn nur ein konstruktor, dann diesen verwenden
-            ctor = ctors[0];
-        }
-        if (ctors.length > 1) {
-            // INFO stefanheimberg: wenn mehrere konstruktor, dann den mit der korrekten signatur verwenden
-            for (Constructor<?> ctor2 : ctors) {
-                final Class<?>[] parameterTypes = ctor2.getParameterTypes();
-                if (parameterTypes.length != args.length) {
-                    // INFO stefanheimberg: anzahl parameter stimmt nicht
-                    continue;
-                }
-                boolean signatureCheckFailed = false;
-                for (int i = 0; i < parameterTypes.length; i++) {
-                    if (args[i] != null && !parameterTypes[i].isAssignableFrom(args[i].getClass())) {
-                        signatureCheckFailed = false;
-                        break;
-                    }
-                }
-                if (!signatureCheckFailed) {
-                    ctor = ctor2;
-                    break;
-                }
-            }
-        }
-        if (null == ctor) {
-            StringBuilder sb = new StringBuilder("No constructor taking:\n");
-            for (Object object : args) {
-                sb.append("\t").append(object.getClass().getName()).append("\n");
-            }
-            throw new RuntimeException(sb.toString());
-        }
-        return ctor;
-    }
+		return createInstance(ctor, rec);
+	}
 
+	private Constructor<?> findConstructor(Class<?> clazz, Object... args) {
+		Constructor<?> result = null;
+		final Constructor<?>[] ctors = clazz.getDeclaredConstructors();
+
+		// More stable check
+		if (ctors.length == 1 && ctors[0].getParameterTypes().length == args.length) {
+			// INFO stefanheimberg: wenn nur ein konstruktor, dann diesen
+			// verwenden
+			result = ctors[0];
+		}
+		if (ctors.length > 1) {
+			// INFO stefanheimberg: wenn mehrere konstruktor, dann den mit der
+			// korrekten signatur verwenden
+
+			NEXT_CONSTRUCTOR: for (Constructor<?> ctor : ctors) {
+				final Class<?>[] parameterTypes = postProcessConstructorParameterTypes(ctor.getParameterTypes());
+				if (parameterTypes.length != args.length) {
+					// INFO stefanheimberg: anzahl parameter stimmt nicht
+					continue NEXT_CONSTRUCTOR;
+				}
+				for (int i = 0; i < parameterTypes.length; i++) {
+					Class<?> argType = convertToBoxTypeIfPrimitive(args[i].getClass());
+					if (args[i] != null && !parameterTypes[i].isAssignableFrom(argType)) {
+						continue NEXT_CONSTRUCTOR;
+					}
+				}
+				result = ctor;
+				break;
+			}
+		}
+		if (null == result) {
+			StringBuilder sb = new StringBuilder("No constructor taking:\n");
+			for (Object object : args) {
+				sb.append("\t").append(object.getClass().getName()).append("\n");
+			}
+			throw new RuntimeException(sb.toString());
+		}
+		return result;
+	}
+
+	/**
+	 * <p>
+	 * According to the JLS primitive types are not assignable to their box type
+	 * counterparts.
+	 * E. g. int.class.isAssignableFrom(Integer.class) returns false.
+	 * </p>
+	 * <p>
+	 * In order to make the isAssignable check in findConstructors work with
+	 * primitives, the check uses this method to convert possible primitive
+	 * constructor argument types to their box type counterparts.
+	 * </p>
+	 */
+	private Class<?>[] postProcessConstructorParameterTypes(Class<?>[] rawParameterTypes) {
+		Class<?>[] result = new Class<?>[rawParameterTypes.length];
+		for (int i = 0; i < rawParameterTypes.length; i++) {
+			Class<?> currentType = rawParameterTypes[i];
+			result[i] = convertToBoxTypeIfPrimitive(currentType);
+		}
+
+		return result;
+	}
+
+	/**
+	 * @return The box type matching the provided primitive type or
+	 *         <code>primitiveType</code> if no match could be found (e. g. the
+	 *         provided value was not a primitive type).
+	 */
+	private Class<?> convertToBoxTypeIfPrimitive(Class<?> primitiveType) {
+		return PRIMITIVE_TO_BOX_TYPE_MAP.getOrDefault(primitiveType, primitiveType);
+	}
 }

--- a/src/main/java/org/qlrm/mapper/JpaResultMapper.java
+++ b/src/main/java/org/qlrm/mapper/JpaResultMapper.java
@@ -79,9 +79,11 @@ public class JpaResultMapper extends ResultMapper {
 					continue NEXT_CONSTRUCTOR;
 				}
 				for (int i = 0; i < parameterTypes.length; i++) {
-					Class<?> argType = convertToBoxTypeIfPrimitive(args[i].getClass());
-					if (args[i] != null && !parameterTypes[i].isAssignableFrom(argType)) {
-						continue NEXT_CONSTRUCTOR;
+					if (args[i] != null) {
+						Class<?> argType = convertToBoxTypeIfPrimitive(args[i].getClass());
+						if (!parameterTypes[i].isAssignableFrom(argType)) {
+							continue NEXT_CONSTRUCTOR;
+						}
 					}
 				}
 				result = ctor;

--- a/src/main/java/org/qlrm/mapper/ResultMapper.java
+++ b/src/main/java/org/qlrm/mapper/ResultMapper.java
@@ -5,19 +5,21 @@ import java.lang.reflect.InvocationTargetException;
 
 public abstract class ResultMapper {
 
-    @SuppressWarnings(value = "unchecked")
-    protected <T> T createInstance(Constructor<?> ctor, Object[] args) {
-        try {
-            return (T) ctor.newInstance(args);
-        } catch (IllegalArgumentException e) {
-            StringBuilder sb = new StringBuilder("no constructor taking:\n");
-            for (Object object : args) {
-                sb.append("\t").append(object.getClass().getName()).append("\n");
-            }
-            throw new RuntimeException(sb.toString(), e);
-        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
-    }
+	@SuppressWarnings(value = "unchecked")
+	protected <T> T createInstance(Constructor<?> ctor, Object[] args) {
+		try {
+			return (T) ctor.newInstance(args);
+		} catch (IllegalArgumentException e) {
+			StringBuilder sb = new StringBuilder("no constructor taking:\n");
+			for (Object object : args) {
+				sb.append("\t").append(object.getClass().getName()).append("\n");
+			}
+			throw new RuntimeException(sb.toString(), e);
+		} catch (InstantiationException | IllegalAccessException e) {
+			throw new RuntimeException(e);
+		} catch (InvocationTargetException e) {
+			throw new RuntimeException(e.getCause());
+		}
+	}
 
 }

--- a/src/test/java/org/qlrm/generator/ClassGeneratorTest.java
+++ b/src/test/java/org/qlrm/generator/ClassGeneratorTest.java
@@ -8,45 +8,48 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ClassGeneratorTest {
 
-    private static Connection con;
-    private static ClassGenerator classGenerator = new ClassGenerator();
+	private static Connection con;
+	private static ClassGenerator classGenerator = new ClassGenerator();
 
-    @BeforeClass
-    public static void setUpClass() {
-        try {
-            Class.forName("org.h2.Driver");
-            con = DriverManager.getConnection("jdbc:h2:mem:test", "sa", "");
-            Statement stmt = con.createStatement();
-            stmt.executeUpdate("CREATE TABLE EMPLOYEE (ID INTEGER NOT NULL, NAME VARCHAR, PRIMARY KEY (ID))");
-            stmt.close();
-        } catch (ClassNotFoundException | SQLException ex) {
-            Logger.getLogger(ClassGeneratorTest.class.getName()).log(Level.SEVERE, null, ex);
-        }
-    }
+	@BeforeClass
+	public static void setUpClass() {
+		try {
+			Class.forName("org.h2.Driver");
+			con = DriverManager.getConnection("jdbc:h2:mem:test", "sa", "");
+			Statement stmt = con.createStatement();
+			stmt.executeUpdate("CREATE TABLE EMPLOYEE (ID INTEGER NOT NULL, NAME VARCHAR, PRIMARY KEY (ID))");
+			stmt.close();
+		} catch (ClassNotFoundException | SQLException ex) {
+			Logger.getLogger(ClassGeneratorTest.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
 
-    @Test
-    public void generateFromTables() {
-        try {
-            classGenerator.generateFromTables(System.getProperty("user.dir"), null, null, false, con, "EMPLOYEE");
-        } catch (SQLException | FileNotFoundException ex) {
-            Logger.getLogger(ClassGeneratorTest.class.getName()).log(Level.SEVERE, null, ex);
-        }
-    }
+	// This test tests the deprecated method itself. Warning is not necessary.
+	@SuppressWarnings("deprecation")
+	@Test
+	public void generateFromTables() {
+		try {
+			classGenerator.generateFromTables(System.getProperty("user.dir"), null, null, false, con, "EMPLOYEE");
+		} catch (SQLException | FileNotFoundException ex) {
+			Logger.getLogger(ClassGeneratorTest.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
 
-    @Test
-    public void generateFromResultSet() {
-        try {
-            Statement stmt = con.createStatement();
-            ResultSet rs = stmt.executeQuery("SELECT NAME FROM EMPLOYEE");
-            classGenerator.generateFromResultSet(System.getProperty("user.dir"), null, "EmployeeNameTO", false, rs);
-            stmt.close();
-        } catch (SQLException | FileNotFoundException ex) {
-            Logger.getLogger(ClassGeneratorTest.class.getName()).log(Level.SEVERE, null, ex);
-        }
-    }
+	@Test
+	public void generateFromResultSet() {
+		try {
+			Statement stmt = con.createStatement();
+			ResultSet rs = stmt.executeQuery("SELECT NAME FROM EMPLOYEE");
+			classGenerator.generateFromResultSet(System.getProperty("user.dir"), null, "EmployeeNameTO", false, rs);
+			stmt.close();
+		} catch (SQLException | FileNotFoundException ex) {
+			Logger.getLogger(ClassGeneratorTest.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
 }

--- a/src/test/java/org/qlrm/mapper/JdbcResultMapperTest.java
+++ b/src/test/java/org/qlrm/mapper/JdbcResultMapperTest.java
@@ -1,66 +1,66 @@
 package org.qlrm.mapper;
 
-import org.qlrm.generator.ClassGenerator;
-import org.qlrm.to.EmployeeTO;
 import java.io.FileNotFoundException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
-import org.junit.Assert;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.qlrm.to.EmployeeTO;
 
 public class JdbcResultMapperTest {
 
-    private static Connection con;
-    private static JdbcResultMapper jdbcResultMapper = new JdbcResultMapper();
-    private static ClassGenerator classGenerator = new ClassGenerator();
+	private static Connection con;
+	private static JdbcResultMapper jdbcResultMapper = new JdbcResultMapper();
 
-    @BeforeClass
-    public static void init() throws SQLException, FileNotFoundException, ClassNotFoundException {
-        Class.forName("org.h2.Driver");
-        con = DriverManager.getConnection("jdbc:h2:mem:test", "sa", "");
-        Statement stmt = con.createStatement();
-        try {
-            stmt.executeUpdate("DROP TABLE EMPLOYEE");
-        } catch (Exception e) {
-        }
-        stmt.executeUpdate("CREATE TABLE EMPLOYEE (ID INTEGER NOT NULL, NAME VARCHAR, PRIMARY KEY (ID))");
-        stmt.executeUpdate("INSERT INTO EMPLOYEE (ID , NAME) VALUES (1, 'Peter Muster')");
-        stmt.close();
+	@BeforeClass
+	public static void init() throws SQLException, FileNotFoundException, ClassNotFoundException {
+		Class.forName("org.h2.Driver");
+		con = DriverManager.getConnection("jdbc:h2:mem:test", "sa", "");
+		Statement stmt = con.createStatement();
+		try {
+			stmt.executeUpdate("DROP TABLE EMPLOYEE");
+		} catch (Exception e) {
+		}
+		stmt.executeUpdate("CREATE TABLE EMPLOYEE (ID INTEGER NOT NULL, NAME VARCHAR, PRIMARY KEY (ID))");
+		stmt.executeUpdate("INSERT INTO EMPLOYEE (ID , NAME) VALUES (1, 'Peter Muster')");
+		stmt.close();
 
-        // FIXME stefanheimberg: deaktiviert weil ohne generierte TO Objekte kompiliert dieser Test auch nicht.
-        // generierung deaktiviert
-        //classGenerator.generateFromTables("src/test/java/", "org.qlrm.to", "TO", false, con, "EMPLOYEE");
-    }
+		// FIXME stefanheimberg: deaktiviert weil ohne generierte TO Objekte
+		// kompiliert dieser Test auch nicht.
+		// generierung deaktiviert
+		// classGenerator.generateFromTables("src/test/java/", "org.qlrm.to",
+		// "TO", false, con, "EMPLOYEE");
+	}
 
-    @Test
-    public void testSql() throws SQLException {
-        Statement stmt = con.createStatement();
-        boolean ok = stmt.execute("SELECT ID, NAME FROM EMPLOYEE");
-        Assert.assertTrue(ok);
+	@Test
+	public void testSql() throws SQLException {
+		Statement stmt = con.createStatement();
+		boolean ok = stmt.execute("SELECT ID, NAME FROM EMPLOYEE");
+		Assert.assertTrue(ok);
 
-        List<EmployeeTO> list = jdbcResultMapper.list(stmt.getResultSet(), EmployeeTO.class);
-        Assert.assertNotNull(list);
-        Assert.assertTrue(list.size() > 0);
+		List<EmployeeTO> list = jdbcResultMapper.list(stmt.getResultSet(), EmployeeTO.class);
+		Assert.assertNotNull(list);
+		Assert.assertTrue(list.size() > 0);
 
-        for (EmployeeTO rec : list) {
-            System.out.println(rec);
-        }
-    }
+		for (EmployeeTO rec : list) {
+			System.out.println(rec);
+		}
+	}
 
-    @Test
-    public void uniqueResult() throws SQLException {
-        Statement stmt = con.createStatement();
-        boolean ok = stmt.execute("SELECT ID, NAME FROM EMPLOYEE WHERE ID = 1");
-        Assert.assertTrue(ok);
+	@Test
+	public void uniqueResult() throws SQLException {
+		Statement stmt = con.createStatement();
+		boolean ok = stmt.execute("SELECT ID, NAME FROM EMPLOYEE WHERE ID = 1");
+		Assert.assertTrue(ok);
 
-        EmployeeTO to = jdbcResultMapper.uniqueResult(stmt.getResultSet(), EmployeeTO.class);
-        Assert.assertNotNull(to);
+		EmployeeTO to = jdbcResultMapper.uniqueResult(stmt.getResultSet(), EmployeeTO.class);
+		Assert.assertNotNull(to);
 
-        System.out.println(to);
-    }
+		System.out.println(to);
+	}
 }

--- a/src/test/java/org/qlrm/mapper/JpaResultMapperTest.java
+++ b/src/test/java/org/qlrm/mapper/JpaResultMapperTest.java
@@ -14,112 +14,113 @@ import javax.persistence.Query;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.qlrm.generator.ClassGenerator;
 import org.qlrm.model.Employee;
 import org.qlrm.to.EmployeeTO;
 
 public class JpaResultMapperTest {
 
-    private static EntityManager em;
-    private static JpaResultMapper jpaResultMapper = new JpaResultMapper();
-    private static ClassGenerator classGenerator = new ClassGenerator();
-    private static int employeeId;
+	private static EntityManager em;
+	private static JpaResultMapper jpaResultMapper = new JpaResultMapper();
+	private static int employeeId;
 
-    @BeforeClass
-    public static void init() throws ClassNotFoundException, SQLException, FileNotFoundException {
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("srm");
-        em = emf.createEntityManager();
-        EntityTransaction trx = em.getTransaction();
-        trx.begin();
-        Employee e = new Employee();
-        e.setName("Peter Muster");
-        em.persist(e);
-        trx.commit();
-        employeeId = e.getId();
+	@BeforeClass
+	public static void init() throws ClassNotFoundException, SQLException, FileNotFoundException {
+		EntityManagerFactory emf = Persistence.createEntityManagerFactory("srm");
+		em = emf.createEntityManager();
+		EntityTransaction trx = em.getTransaction();
+		trx.begin();
+		Employee e = new Employee();
+		e.setName("Peter Muster");
+		em.persist(e);
+		trx.commit();
+		employeeId = e.getId();
 
-        // FIXME stefanheimberg: deaktiviert weil ohne generierte TO Objekte kompiliert dieser Test auch nicht.
-        // generierung deaktiviert
-        //Class.forName("org.h2.Driver");
-        //Connection con = DriverManager.getConnection("jdbc:h2:mem:test", "sa", "");
-        //classGenerator.generateFromTables("src/test/java/", "org.qlrm.to", "TO", false, con, "EMPLOYEE");
-    }
+		// FIXME stefanheimberg: deaktiviert weil ohne generierte TO Objekte
+		// kompiliert dieser Test auch nicht.
+		// generierung deaktiviert
+		// Class.forName("org.h2.Driver");
+		// Connection con = DriverManager.getConnection("jdbc:h2:mem:test",
+		// "sa", "");
+		// classGenerator.generateFromTables("src/test/java/", "org.qlrm.to",
+		// "TO", false, con, "EMPLOYEE");
+	}
 
-    @Test
-    public void listWithSql() {
-        Query q = em.createNativeQuery("SELECT ID, NAME FROM EMPLOYEE");
-        List<EmployeeTO> list = jpaResultMapper.list(q, EmployeeTO.class);
+	@Test
+	public void listWithSql() {
+		Query q = em.createNativeQuery("SELECT ID, NAME FROM EMPLOYEE");
+		List<EmployeeTO> list = jpaResultMapper.list(q, EmployeeTO.class);
 
-        Assert.assertNotNull(list);
-        for (EmployeeTO rec : list) {
-            System.out.println(rec);
-        }
-    }
+		Assert.assertNotNull(list);
+		for (EmployeeTO rec : list) {
+			System.out.println(rec);
+		}
+	}
 
-    @Test
-    public void listWithJpql() {
-        Query q = em.createQuery("SELECT e.id, e.name FROM Employee e");
-        List<EmployeeTO> list = jpaResultMapper.list(q, EmployeeTO.class);
+	@Test
+	public void listWithJpql() {
+		Query q = em.createQuery("SELECT e.id, e.name FROM Employee e");
+		List<EmployeeTO> list = jpaResultMapper.list(q, EmployeeTO.class);
 
-        Assert.assertNotNull(list);
-        for (EmployeeTO rec : list) {
-            System.out.println(rec);
-        }
-    }
+		Assert.assertNotNull(list);
+		for (EmployeeTO rec : list) {
+			System.out.println(rec);
+		}
+	}
 
-    @Test
-    public void listWithJpqlWhenUniqueResult() {
-        Query q = em.createQuery("SELECT e.id FROM Employee e");
-        List<Long> list = jpaResultMapper.list(q, Long.class);
+	@Test
+	public void listWithJpqlWhenUniqueResult() {
+		Query q = em.createQuery("SELECT e.id FROM Employee e");
+		List<Long> list = jpaResultMapper.list(q, Long.class);
 
-        Assert.assertNotNull(list);
-        Assert.assertEquals(1, list.size());
-        Assert.assertEquals(employeeId, list.get(0).longValue());
-    }
+		Assert.assertNotNull(list);
+		Assert.assertEquals(1, list.size());
+		Assert.assertEquals(employeeId, list.get(0).longValue());
+	}
 
-    @Test
-    public void listWithJpqlWithNoResult() {
-        Query q = em.createQuery("SELECT e FROM Employee e WHERE e.id=?1");
-        q.setParameter(1, employeeId + 1);
+	@Test
+	public void listWithJpqlWithNoResult() {
+		Query q = em.createQuery("SELECT e FROM Employee e WHERE e.id=?1");
+		q.setParameter(1, employeeId + 1);
 
-        List<Long> list = jpaResultMapper.list(q, Long.class);
+		List<Long> list = jpaResultMapper.list(q, Long.class);
 
-        Assert.assertNotNull(list);
-        Assert.assertTrue(list.isEmpty());
-    }
+		Assert.assertNotNull(list);
+		Assert.assertTrue(list.isEmpty());
+	}
 
-    @Test
-    public void uniqueResultWithSql() {
-        Query q = em.createNativeQuery("SELECT ID, NAME FROM EMPLOYEE WHERE ID = 1");
-        EmployeeTO to = jpaResultMapper.uniqueResult(q, EmployeeTO.class);
+	@Test
+	public void uniqueResultWithSql() {
+		Query q = em.createNativeQuery("SELECT ID, NAME FROM EMPLOYEE WHERE ID = 1");
+		EmployeeTO to = jpaResultMapper.uniqueResult(q, EmployeeTO.class);
 
-        Assert.assertNotNull(to);
-        System.out.println(to);
-    }
+		Assert.assertNotNull(to);
+		System.out.println(to);
+	}
 
-    @Test
-    public void uniqueResultWithJpqlWhenSingleRow() {
-        Query q = em.createNativeQuery("SELECT e.id, e.name FROM Employee e WHERE e.id = 1");
-        EmployeeTO to = jpaResultMapper.uniqueResult(q, EmployeeTO.class);
+	@Test
+	public void uniqueResultWithJpqlWhenSingleRow() {
+		Query q = em.createNativeQuery("SELECT e.id, e.name FROM Employee e WHERE e.id = 1");
+		EmployeeTO to = jpaResultMapper.uniqueResult(q, EmployeeTO.class);
 
-        Assert.assertNotNull(to);
-        System.out.println(to);
-    }
+		Assert.assertNotNull(to);
+		System.out.println(to);
+	}
 
-    @Test
-    public void uniqueResultWithJpqlWhenSingleResult() {
-        Query q = em.createQuery("SELECT COUNT(e) FROM Employee e");
-        Long result = jpaResultMapper.uniqueResult(q, Long.class);
+	@Test
+	public void uniqueResultWithJpqlWhenSingleResult() {
+		Query q = em.createQuery("SELECT COUNT(e) FROM Employee e");
+		Long result = jpaResultMapper.uniqueResult(q, Long.class);
 
-        Assert.assertNotNull(result);
-        Assert.assertEquals(employeeId, result.longValue());
-    }
+		Assert.assertNotNull(result);
+		Assert.assertEquals(employeeId, result.longValue());
+	}
 
-    @Test(expected = NoResultException.class)
-    public void uniqueResultWithJpqlWhenNoResult() {
-        Query q = em.createQuery("SELECT e FROM Employee e WHERE e.id=?1");
-        q.setParameter(1, employeeId + 1);
+	@Test(expected = NoResultException.class)
+	public void uniqueResultWithJpqlWhenNoResult() {
+		Query q = em.createQuery("SELECT e FROM Employee e WHERE e.id=?1");
+		q.setParameter(1, employeeId + 1);
 
-        jpaResultMapper.uniqueResult(q, Long.class);
-        Assert.fail("Expected " + NoResultException.class.getSimpleName() + " but not exception was thrown.");
-    }
+		jpaResultMapper.uniqueResult(q, Long.class);
+		Assert.fail("Expected " + NoResultException.class.getSimpleName() + " but not exception was thrown.");
+	}
 }

--- a/src/test/java/org/qlrm/to/EmployeeTO.java
+++ b/src/test/java/org/qlrm/to/EmployeeTO.java
@@ -1,48 +1,43 @@
 package org.qlrm.to;
 
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.math.BigDecimal;
-
-
 public class EmployeeTO {
 
-  private Integer id;
-  private String name;
+	private Integer id;
+	private String name;
 
-  /**
-   * INFO stefanheimberg: konstruktor bewusst für tests erstellt.
-   */
-  public EmployeeTO (String name, Integer id) {
+	/**
+	 * INFO stefanheimberg: konstruktor bewusst für tests erstellt.
+	 */
+	public EmployeeTO(String name, Integer id) {
 
-    this.id = id;
-    this.name = name;
+		this.id = id;
+		this.name = name;
 
-  }
+	}
 
-  public EmployeeTO (Integer id, String name) {
+	public EmployeeTO(Integer id, String name) {
 
-    this.id = id;
-    this.name = name;
+		this.id = id;
+		this.name = name;
 
-  }
+	}
 
-  /**
-   * INFO stefanheimberg: konstruktor bewusst für tests erstellt.
-   */
-  public EmployeeTO (Integer id, String name, Integer anyOtherParam) {
+	/**
+	 * INFO stefanheimberg: konstruktor bewusst für tests erstellt.
+	 */
+	public EmployeeTO(Integer id, String name, Integer anyOtherParam) {
 
-    this.id = id;
-    this.name = name;
+		this.id = id;
+		this.name = name;
 
-  }
+	}
 
-  public Integer getId() {
-    return id;
- }
-  public String getName() {
-    return name;
- }
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
 
 }


### PR DESCRIPTION
Hi there,

i noticed the following issues the other day and fixed them:

* If a result row column contains primitives, the findConstructor algorithm fails to find a matching constructor if the constructors do use box types or vice versa, e. g. the column contains an int but the constructor of the corresponding POJO takes an Integer.

* If a result row column contains a null reference, an InvocationTargetException having an NPE set as cause might be thrown (depending on the behavior of the POJO's constructor when null arguments are passed). I straightened out the exception handling a bit so that debugging via stack trace gets easier in such situations.

I did also fix a couple of minor issues in the JpaResultMapper unit test cases.

Unfortunately my IDE seems to have a slightly different tab/spaces policy than yours resulting in rather large diffs. If that bothers you, I could try to change the settings and replay my changes.

Regards